### PR TITLE
fix toTop in Firefox

### DIFF
--- a/source/script/nlvi.js
+++ b/source/script/nlvi.js
@@ -98,7 +98,7 @@
                 })
             })
             $('.toTop').click(function() {
-                $('body').animate({ scrollTop: 0 })
+                $('html, body').animate({ scrollTop: 0 })
             })
         },
 


### PR DESCRIPTION
Hi,
In Firefox the scroll-to-top button doesn't work, when animation targets 'body'. 
Seems to be a browser compatibility issue, as mentioned [here](https://stackoverflow.com/questions/18779708/scrolltop-with-animate-not-working).