### PR TITLE
Skip escaping the paginator parameters.

### DIFF
--- a/layout/_partial/pagenum.swig
+++ b/layout/_partial/pagenum.swig
@@ -2,7 +2,8 @@
   <nav class="pagination">
       {{ paginator({
           prev_text: '<i class="iconfont icon-doubleleft"></i>' + __("page.prev"),
-          next_text: __("page.next") + '<i class="iconfont icon-doubleright"></i>'
+          next_text: __("page.next") + '<i class="iconfont icon-doubleright"></i>',
+          escape: false
       }) }}
   </nav>
 {% else %}


### PR DESCRIPTION
The swig will escape the `<i>` tag when preform string concating,
and in this case, the decorator is not applied in the pagination area.
