### PR TITLE
添加Mathjax3的支持

### DIFF
--- a/_config.template.yml
+++ b/_config.template.yml
@@ -124,6 +124,7 @@ pjax: false
 
 # mathjax
 mathjax: false
+mathjax3: false
 
 # lightbox
 lightbox: true

--- a/layout/_partial/post.swig
+++ b/layout/_partial/post.swig
@@ -1,8 +1,4 @@
 {% macro render(post) %}
-  {% if page.mathjax %}
-    <script src="https://cdn.bootcss.com/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-    <script type="text/x-mathjax-config;executed=true">MathJax.Hub.Config({tex2jax: {inlineMath: [["$","$"], ["\\(","\\)"]]}});</script>
-  {% endif %}
   <article class="
   post
   {% if is_post() %} is_post {% endif %}

--- a/layout/_script/script.swig
+++ b/layout/_script/script.swig
@@ -10,6 +10,18 @@
   <script type="text/x-mathjax-config;executed=true">MathJax.Hub.Config({tex2jax: {inlineMath: [["$","$"], ["\\(","\\)"]]}});</script>
 {% endif %}
 
+{% if theme.mathjax3 %}
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script>
+    MathJax = {
+      tex: {
+        tags: 'ams'
+      }
+    };
+  </script>
+  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+{% endif %}
+
 {% if theme.lazyload %}
   <script src="https://unpkg.com/lazysizes@5.1.1/lazysizes.min.js" async></script>
 {% endif %}


### PR DESCRIPTION
目前的Mathjax是2.x的，考虑到可能会有其他人继续使用，加一个新版本(3.x)的标记。

其实理想状态下最好可以通过`mathjaxVersion`之类的来做自定化，但是由于2和3的配置和js导入差异性比较大，要自定化也是2.x和3.x分别做版本自定化，看上去没特别大的必要。

另外，最开始由我的gist导过来的`post.swig`已经不需要导入（项目中导入导致了两个文件版本不一致，虽然`post.swig`那部分似乎被`script.swig`覆盖了。